### PR TITLE
Fix a couple of warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --require spec_helper
+--warnings

--- a/lib/variant.rb
+++ b/lib/variant.rb
@@ -36,15 +36,15 @@ module Variant
 	#
 	def self.force!(value, environment = ENV, **overrides)
 		# Clear any specific variants:
-		environment.delete_if{|key, value| key.end_with?(SUFFIX)}
+		environment.delete_if{|key, _| key.end_with?(SUFFIX)}
 		
 		# Set the specified variant:
 		environment[KEY] = value.to_s
 		
-		overrides.each do |name, value|
+		overrides.each do |name, new_value|
 			key = name.upcase.to_s + SUFFIX
 			
-			environment[key] = value.to_s
+			environment[key] = new_value.to_s
 		end
 		
 		return environment


### PR DESCRIPTION
This fixes a pair of warnings when running tests with warnings enabled:
```
/Users/michael/Code/Socketry/variant/lib/variant.rb:39: warning: shadowing outer local variable - value
/Users/michael/Code/Socketry/variant/lib/variant.rb:44: warning: shadowing outer local variable - value
```

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
